### PR TITLE
Properly escape special characters in regular expression

### DIFF
--- a/tests/test_part_image.py
+++ b/tests/test_part_image.py
@@ -62,7 +62,7 @@ def print_partition_table(disk_image):
 
         line = line.strip()
         if payload:
-            match = re.match("^\s*([0-9]+)\s+([0-9]+)\s*$", line)
+            match = re.match(r"^\s*([0-9]+)\s+([0-9]+)\s*$", line)
             assert(match is not None)
             starts.append(int(match.group(1)) * 512)
             # +1 because end position is inclusive.


### PR DESCRIPTION
Clears up warning `DeprecationWarning: invalid escape sequence \s`