### PR TITLE
test_standalone_update_rollback: Set to min mender 2.3.1

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -930,7 +930,7 @@ class TestUpdates:
             os.remove("image.mender")
             os.remove("image.dat")
 
-    @pytest.mark.min_mender_version("2.0.0")
+    @pytest.mark.min_mender_version("2.3.1")
     def test_standalone_update_rollback(self, bitbake_variables, connection):
         """Test that the rollback state on the active partition does roll back to the
         currently running active partition after a failed update.


### PR DESCRIPTION
The bugfix is not available for earlier versions of the client.