### PR TITLE
rename: min_mender_version -> min_mender_client_version

### DIFF
--- a/tests/test_part_image.py
+++ b/tests/test_part_image.py
@@ -104,7 +104,7 @@ def get_data_part_number(disk_image):
 
 
 @pytest.mark.only_with_image("sdimg", "uefiimg")
-@pytest.mark.min_mender_version("1.0.0")
+@pytest.mark.min_mender_client_version("1.0.0")
 class TestMostPartitionImages:
     @staticmethod
     def verify_fstab(data):
@@ -379,7 +379,7 @@ class TestMostPartitionImages:
 
 
 @pytest.mark.only_with_image("sdimg", "uefiimg", "biosimg", "gptimg")
-@pytest.mark.min_mender_version("1.0.0")
+@pytest.mark.min_mender_client_version("1.0.0")
 class TestAllPartitionImages:
     @pytest.mark.min_yocto_version("warrior")
     @pytest.mark.conversion

--- a/tests/test_rootfs.py
+++ b/tests/test_rootfs.py
@@ -54,7 +54,7 @@ class TestRootfs:
             occurred[cols[1]] = True
 
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_expected_files_ext234(
         self, bitbake_path, bitbake_variables, latest_rootfs
     ):
@@ -123,7 +123,7 @@ class TestRootfs:
                 raise
 
     @pytest.mark.only_with_image("ubifs")
-    @pytest.mark.min_mender_version("1.2.0")
+    @pytest.mark.min_mender_client_version("1.2.0")
     def test_expected_files_ubifs(self, bitbake_path, bitbake_variables, latest_ubifs):
         """Test that artifact_info file is correctly embedded."""
 
@@ -150,7 +150,7 @@ class TestRootfs:
             TestRootfs.verify_fstab(data)
 
     @pytest.mark.only_with_distro_feature("mender-convert")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_unconfigured_image(self, latest_rootfs):
         """Test that images from mender-convert are unconfigured. We want
         `mender setup` to be the configuration mechanism there."""

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -74,7 +74,7 @@ class SignatureCase:
 
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestUpdates:
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_broken_image_update(self, bitbake_variables, connection):
 
         file_flag = Helpers.get_file_flag(bitbake_variables)
@@ -125,7 +125,7 @@ class TestUpdates:
             if os.path.exists("image.dat"):
                 os.remove("image.dat")
 
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_too_big_image_update(self, bitbake_variables, connection):
 
         file_flag = Helpers.get_file_flag(bitbake_variables)
@@ -167,7 +167,7 @@ class TestUpdates:
             if os.path.exists("image.dat"):
                 os.remove("image.dat")
 
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_network_based_image_update(
         self,
         successful_image_update_mender,
@@ -541,7 +541,7 @@ class TestUpdates:
             ),
         ],
     )
-    @pytest.mark.min_mender_version("1.1.0")
+    @pytest.mark.min_mender_client_version("1.1.0")
     def test_signed_updates(self, sig_case, bitbake_variables, connection):
         """Test various combinations of signed and unsigned, present and non-
         present verification keys."""
@@ -777,7 +777,7 @@ class TestUpdates:
                 )
 
     @pytest.mark.only_with_distro_feature("mender-grub")
-    @pytest.mark.min_mender_version("1.0.0")
+    @pytest.mark.min_mender_client_version("1.0.0")
     def test_redundant_grub_env(
         self, successful_image_update_mender, bitbake_variables, connection
     ):
@@ -849,7 +849,7 @@ class TestUpdates:
 
     @pytest.mark.only_with_distro_feature("mender-uboot")
     @pytest.mark.only_with_image("sdimg", "uefiimg")
-    @pytest.mark.min_mender_version("1.6.0")
+    @pytest.mark.min_mender_client_version("1.6.0")
     def test_uboot_mender_saveenv_canary(self, bitbake_variables, connection):
         """Tests that the mender_saveenv_canary works correctly, which tests
         that Mender will not proceed unless the U-Boot boot loader has saved the
@@ -930,7 +930,7 @@ class TestUpdates:
             os.remove("image.mender")
             os.remove("image.dat")
 
-    @pytest.mark.min_mender_version("2.3.1")
+    @pytest.mark.min_mender_client_version("2.3.1")
     def test_standalone_update_rollback(self, bitbake_variables, connection):
         """Test that the rollback state on the active partition does roll back to the
         currently running active partition after a failed update.


### PR DESCRIPTION
To align with acceptance tests in:

 https://github.com/mendersoftware/meta-mender/pull/1158

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>