### PR TITLE
[test_update] Mark test_uboot_mender_saveenv_canary for dunfell

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -857,6 +857,7 @@ class TestUpdates:
     @pytest.mark.only_with_mender_feature("mender-uboot")
     @pytest.mark.only_with_image("sdimg", "uefiimg")
     @pytest.mark.min_mender_version("1.6.0")
+    @pytest.mark.min_yocto_version("dunfell")
     def test_uboot_mender_saveenv_canary(self, bitbake_variables, connection):
         """Tests that the mender_saveenv_canary works correctly, which tests
         that Mender will not proceed unless the U-Boot boot loader has saved the


### PR DESCRIPTION
The second part of this test, which zeroes the environment and expects
fw_printenv to fail, fails on zeus (and older, if run) due to the
using u-boot-fw-utils which has a default environment.