### PR TITLE
Register the missing 'not_for_machine' pytest marker

### DIFF
--- a/tests/utils/parseropts/parseropts.py
+++ b/tests/utils/parseropts/parseropts.py
@@ -127,6 +127,9 @@ def pytest_configure(config):
         "markers",
         "conversion: mark test to run only when --test-conversion cli parameter is provided",
     )
+    config.addinivalue_line(
+        "markers", "not_for_machine: exclude only for the given machine"
+    )
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
Ref:
https://northern-tech.slack.com/archives/C2D3HRU9M/p1607442874010000?thread_ts=1607441097.005200&cid=C2D3HRU9M