### PR TITLE
Remove "conversion" marker and logic to skip tests based on this

### DIFF
--- a/tests/test_part_image.py
+++ b/tests/test_part_image.py
@@ -384,7 +384,6 @@ class TestMostPartitionImages:
 @pytest.mark.min_mender_version("1.0.0")
 class TestAllPartitionImages:
     @pytest.mark.min_yocto_version("warrior")
-    @pytest.mark.conversion
     def test_equal_checksum_part_image_and_artifact(
         self, bitbake_variables, latest_part_image, latest_mender_image
     ):

--- a/tests/utils/parseropts/parseropts.py
+++ b/tests/utils/parseropts/parseropts.py
@@ -124,21 +124,5 @@ def pytest_configure(config):
     )
     config.addinivalue_line("markers", "commercial: run commercial tests")
     config.addinivalue_line(
-        "markers",
-        "conversion: mark test to run only when --test-conversion cli parameter is provided",
-    )
-    config.addinivalue_line(
         "markers", "not_for_machine: exclude only for the given machine"
     )
-
-
-def pytest_collection_modifyitems(config, items):
-    if config.getoption("--test-conversion"):
-        # --test-conversion given so do not skip conversion tests
-        return
-    skip_conversion = pytest.mark.skip(
-        reason="conversion tests not yet working in Yocto"
-    )
-    for item in items:
-        if "conversion" in item.keywords:
-            item.add_marker(skip_conversion)


### PR DESCRIPTION
It seems to have been introduced by mistake during the Python3 upgrade
in November 2019.

Before this refactoring, there was no marker nor logic to skip any test
based on this; it was only used inside fixtures or specific tests to
modify their behaviour (for example, to decide on the path where the
image under test is expected to be).

See:
* https://github.com/mendersoftware/mender-image-tests/commit/a6cfbd1b09412784dcdd0dabaa67662129a8ff87
* https://github.com/mendersoftware/meta-mender/commit/a12742dc4aceeb6e560242590c5f42ce4c3868cc

Also, generally speaking, any test that is in this submodule is expected
to be run both on mender-convert and meta-mender (some configuration
exceptions may apply to the latter), but in any case a "conversion only"
test would need to live in mender-convert repository and not here.