### PR TITLE
test_rootfs: Add test for mender-shell installation

### DIFF
--- a/tests/test_rootfs.py
+++ b/tests/test_rootfs.py
@@ -15,6 +15,7 @@
 
 import subprocess
 import os
+import json
 
 import pytest
 
@@ -58,7 +59,7 @@ class TestRootfs:
     def test_expected_files_ext234(
         self, bitbake_path, bitbake_variables, latest_rootfs
     ):
-        """Test that artifact_info file is correctly embedded."""
+        """Test mender client expected files"""
 
         with make_tempdir() as tmpdir:
             try:
@@ -139,6 +140,42 @@ class TestRootfs:
                 print("Contents of artifact_info:")
                 subprocess.call(["cat", "artifact_info"])
                 raise
+
+    @pytest.mark.not_with_mender_feature("mender-convert")
+    @pytest.mark.only_with_image("ext4", "ext3", "ext2")
+    @pytest.mark.min_mender_version("2.5.0")
+    def test_expected_files_ext234_mender_shell(
+        self, bitbake_path, bitbake_variables, latest_rootfs
+    ):
+        """Test mender-shell expected files"""
+
+        with make_tempdir() as tmpdir:
+            # Check whether mender-shell exists in /usr/bin
+            output = subprocess.check_output(
+                ["debugfs", "-R", "ls -l -p /usr/bin", latest_rootfs], cwd=tmpdir
+            ).decode()
+            assert any(
+                [
+                    line.split("/")[5] == "mender-shell"
+                    for line in output.split("\n")
+                    if len(line) > 0
+                ]
+            )
+
+            # Check whether mender-shell.conf has the correct contents
+            subprocess.check_call(
+                [
+                    "debugfs",
+                    "-R",
+                    "dump -p /etc/mender/mender-shell.conf mender-shell.conf",
+                    latest_rootfs,
+                ],
+                cwd=tmpdir,
+            )
+            with open(os.path.join(tmpdir, "mender-shell.conf")) as fd:
+                mender_shell_vars = json.load(fd)
+            assert len(mender_shell_vars) == 1, mender_shell_vars
+            assert "ServerURL" in mender_shell_vars, mender_shell_vars
 
     @pytest.mark.only_with_image("ubifs")
     @pytest.mark.min_mender_version("1.2.0")

--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -656,6 +656,29 @@ def only_with_mender_feature(request, bitbake_variables):
             )
 
 
+@pytest.fixture(autouse=True)
+def not_with_mender_feature(request, bitbake_variables):
+    """Fixture that enables use of `not_with_mender_feature(feature1, feature2)` mark.
+    Example::
+
+       @pytest.mark.not_with_mender_feature('mender-uboot')
+       def test_foo():
+           # executes only if mender-uboot feature is not enabled
+           pass
+
+    """
+
+    mark = request.node.get_closest_marker("not_with_mender_feature")
+    if mark is not None:
+        features = mark.args
+        current = bitbake_variables.get("MENDER_FEATURES", "").strip().split()
+        if any([feature in current for feature in features]):
+            pytest.skip(
+                "supported distro feature in {} "
+                "(excludes {})".format(", ".join(current), ", ".join(features))
+            )
+
+
 @pytest.fixture(scope="session")
 def host(request):
     return request.config.getoption("--host")

--- a/tests/utils/parseropts/parseropts.py
+++ b/tests/utils/parseropts/parseropts.py
@@ -122,6 +122,10 @@ def pytest_configure(config):
         "markers",
         "only_with_mender_feature: execute only if all given features are enabled",
     )
+    config.addinivalue_line(
+        "markers",
+        "not_with_mender_feature: execute only if any features is not enabled",
+    )
     config.addinivalue_line("markers", "commercial: run commercial tests")
     config.addinivalue_line(
         "markers", "not_for_machine: exclude only for the given machine"


### PR DESCRIPTION
And a corresponding fixture to skip tests (like this one) that are not
applicable for a given feature (mender-convert in this case).