### PR TITLE
Move build definition to meta-mender build files instead of scripts.

### DIFF
--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -407,10 +407,7 @@ def build_image_fn(request, conversion, prepared_test_build_base, bitbake_image)
             prepared_test_build_base["build_dir"],
             prepared_test_build_base["bitbake_corebase"],
             bitbake_image,
-            [
-                'SYSTEMD_AUTO_ENABLE_pn-mender-client = "disable"',
-                'EXTRA_IMAGE_FEATURES_append = " ssh-server-openssh"',
-            ],
+            ['EXTRA_IMAGE_FEATURES_append = " ssh-server-openssh"',],
         )
         return prepared_test_build_base["build_dir"]
 


### PR DESCRIPTION
Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>