### PR TITLE
Update tests to match the latest meta-mender

### DIFF
--- a/tests/test_rootfs.py
+++ b/tests/test_rootfs.py
@@ -199,8 +199,9 @@ class TestRootfs:
                 )
                 with open(os.path.join(tmpdir, "mender-connect.conf")) as fd:
                     mender_connect_vars = json.load(fd)
-                assert len(mender_connect_vars) == 2, mender_connect_vars
+                assert len(mender_connect_vars) == 3, mender_connect_vars
                 assert "ServerURL" in mender_connect_vars, mender_connect_vars
+                assert "Shell" in mender_connect_vars, mender_connect_vars
                 assert "User" in mender_connect_vars, mender_connect_vars
 
     @pytest.mark.only_with_image("ubifs")


### PR DESCRIPTION
meta-mender-demo sets the mender-connect shell to /bin/bash; update the
tests to match this new setting.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio@tranchitella.eu>