### PR TITLE
MEN-4256: test_rootfs.py: Remove checks for artifact_info file (+ misc)

### DIFF
--- a/tests/test_part_image.py
+++ b/tests/test_part_image.py
@@ -245,7 +245,7 @@ class TestMostPartitionImages:
 
         except:
             subprocess.call(["ls", "-l", "device_type"])
-            print("Contents of artifact_info:")
+            print("Contents of device_type:")
             subprocess.call(["cat", "device_type"])
             raise
 

--- a/tests/test_part_image.py
+++ b/tests/test_part_image.py
@@ -421,15 +421,18 @@ class TestAllPartitionImages:
     ):
         bufsize = 1048576  # 1MiB
         if b".xz" in subprocess.check_output(["tar", "tf", latest_mender_image]):
-            zext = "xz"
+            zext = ".xz"
             ztar = "J"
-        else:
-            zext = "gz"
+        elif b".gz" in subprocess.check_output(["tar", "tf", latest_mender_image]):
+            zext = ".gz"
             ztar = "z"
+        else:
+            zext = ""
+            ztar = ""
 
         with tempfile.NamedTemporaryFile() as tmp_artifact:
             subprocess.check_call(
-                "tar xOf %s data/0000.tar.%s | tar x%sO > %s"
+                "tar xOf %s data/0000.tar%s | tar x%sO > %s"
                 % (latest_mender_image, zext, ztar, tmp_artifact.name),
                 shell=True,
             )


### PR DESCRIPTION
This file won't be present in some mender-convert images from now on.
And having plans to remove the file all together soon, it makes no sense
complicating the test logic to make this check conditional.

Plus couple of misc fixes:
* test_device_type: fix typo
* test_equal_checksum_part_image_and_artifact: support uncompressed
Support extracting an uncompressed file system from the Artifact.