### PR TITLE
paramiko: set look_for_keys and allow_agent to False

### DIFF
--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -58,7 +58,13 @@ def config_host(host):
 
 def connection_factory(request, user, host, ssh_priv_key):
     host, port = config_host(host)
-    connect_kwargs = {"password": "", "banner_timeout": 60, "auth_timeout": 60}
+    connect_kwargs = {
+        "password": "",
+        "banner_timeout": 60,
+        "auth_timeout": 60,
+        "look_for_keys": False,
+        "allow_agent": False,
+    }
     if ssh_priv_key != "":
         connect_kwargs["key_filename"] = ssh_priv_key
     conn = Connection(


### PR DESCRIPTION
Following changes from integration test framework. See:
* https://github.com/mendersoftware/integration/pull/1333
* https://github.com/mendersoftware/integration/pull/1336