### PR TITLE
test_expected_files_ext234: only with feature "mender-client-install"

### DIFF
--- a/tests/test_rootfs.py
+++ b/tests/test_rootfs.py
@@ -64,6 +64,7 @@ class TestRootfs:
         )
         assert os.access(os.path.join(tmpdir, filename), os.X_OK)
 
+    @pytest.mark.only_with_mender_feature("mender-client-install")
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
     @pytest.mark.min_mender_version("2.5.0")
     def test_expected_files_ext234(


### PR DESCRIPTION
So that the test can be skip for images containing no client (like the
pre-built images from mender-convert).