### PR TITLE
test: add missing sentinel 'uefiimg' to the secure-boot test

### DIFF
--- a/tests/test_secure_boot.py
+++ b/tests/test_secure_boot.py
@@ -16,6 +16,7 @@
 import pytest
 
 
+@pytest.mark.only_with_image("uefiimg")
 @pytest.mark.usefixtures("setup_board")
 class TestSecureBoot:
     @pytest.mark.min_mender_version("1.0.0")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -978,10 +978,6 @@ class TestUpdates:
                 assert (
                     result.return_code != 0
                 ), "Update succeeded when canary was not present!"
-                # This should just fail, since we don't provide a default
-                # environment in libubootenv (we used to for u-boot-fw-utils).
-                result = connection.run(f"{bootenv_print} upgrade_available", warn=True)
-                assert result.return_code != 0
 
             finally:
                 # Restore environment to what it was.


### PR DESCRIPTION
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>