### PR TITLE
chore: Move IMAGE_FEATURES setting to meta-mender.

### DIFF
--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -387,7 +387,6 @@ def build_image_fn(request, conversion, prepared_test_build_base, bitbake_image)
             prepared_test_build_base["build_dir"],
             prepared_test_build_base["bitbake_corebase"],
             bitbake_image,
-            ['EXTRA_IMAGE_FEATURES_append = " ssh-server-openssh"',],
         )
         return prepared_test_build_base["build_dir"]
 


### PR DESCRIPTION
This way we avoid having to deal with the new ":" syntax, which may
become a problem if we import the repo to an old meta-mender branch.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>