### PR TITLE
chore: Move IMAGE_FEATURES setting to meta-mender.

### DIFF
--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -370,7 +370,6 @@ def build_image_fn(request, conversion, prepared_test_build_base, bitbake_image)
             prepared_test_build_base["build_dir"],
             prepared_test_build_base["bitbake_corebase"],
             bitbake_image,
-            ['EXTRA_IMAGE_FEATURES_append = " ssh-server-openssh"',],
         )
         return prepared_test_build_base["build_dir"]
 


### PR DESCRIPTION
Meta-mender/dunfell is far behind the master branch of this repository. Therefore I decided to fork into a new dunfell branch and cherry-pick this specific fix. There are quite a lot of changes in the master branch that aren't appropriate for meta-mender/dunfell, so rather than sprinkle a lot of conditions everywhere, I decided to make a clean break here.