### PR TITLE
ci(scp): Fall back to the legacy SCP protocol

### DIFF
--- a/tests/utils/common/common.py
+++ b/tests/utils/common/common.py
@@ -223,7 +223,7 @@ def determine_active_passive_part(bitbake_variables, conn):
 
 
 def get_ssh_common_args(conn):
-    args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    args = "-O -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     if "key_filename" in conn.connect_kwargs.keys():
         args += " -i %s" % conn.connect_kwargs["key_filename"]
     return args


### PR DESCRIPTION
New versions of the scp program uses the SFTP protocol by
default. However SFTP is not installed in our qemu hosts, and hence
this does not work.

The fix is simple. Fall back to the legacy functionality. The SCP
protocol, though aged, works just fine for our needs.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>