### PR TITLE
test: Fix `--capture` option by removing Fabric.

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -20,8 +20,6 @@ import shutil
 import subprocess
 import tempfile
 
-from fabric import Connection
-from invoke import UnexpectedExit
 import pytest
 
 from utils.common import (
@@ -803,12 +801,7 @@ class TestUpdates:
                 ).stdout
                 assert content == expected_content, "Case: %s" % sig_case.label
 
-            # In Fabric context, SystemExit means CalledProcessError. We should
-            # not catch all exceptions, because we want to leave assertions
-            # alone.
-            # In Fabric2 there might be different exception thrown in that case
-            # which is UnexpectedExit.
-            except (SystemExit, UnexpectedExit):
+            except subprocess.CalledProcessError:
                 if (
                     "mender-ubi" in bitbake_variables.get("MENDER_FEATURES", "").split()
                     or "mender-ubi"

--- a/tests/utils/common/common.py
+++ b/tests/utils/common/common.py
@@ -280,7 +280,7 @@ def determine_active_passive_part(bitbake_variables, conn):
 
 
 def get_ssh_common_args(conn):
-    args = "-O -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+    args = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
     if "key_filename" in conn.connect_kwargs.keys():
         args += " -i %s" % conn.connect_kwargs["key_filename"]
     return args
@@ -288,7 +288,7 @@ def get_ssh_common_args(conn):
 
 # Yocto build SSH is lacking SFTP, let's override and use regular SCP instead.
 def put_no_sftp(file, conn, remote="."):
-    cmd = "scp %s" % get_ssh_common_args(conn)
+    cmd = "scp -O %s" % get_ssh_common_args(conn)
     conn.local(
         "%s -P %s %s %s@%s:%s" % (cmd, conn.port, file, conn.user, conn.host, remote)
     )
@@ -296,7 +296,7 @@ def put_no_sftp(file, conn, remote="."):
 
 # Yocto build SSH is lacking SFTP, let's override and use regular SCP instead.
 def get_no_sftp(file, conn, local="."):
-    cmd = "scp %s" % get_ssh_common_args(conn)
+    cmd = "scp -O %s" % get_ssh_common_args(conn)
     conn.local(
         "%s -P %s %s@%s:%s %s" % (cmd, conn.port, conn.user, conn.host, file, local)
     )

--- a/tests/utils/common/common.py
+++ b/tests/utils/common/common.py
@@ -209,7 +209,7 @@ def start_qemu_flash(latest_vexpress_nor, conn, qemu_wrapper):
     return qemu, img_path
 
 
-def reboot(conn, wait=120):
+def reboot(conn, wait=360):
     try:
         conn.run("reboot", warn=True)
     except:
@@ -229,7 +229,7 @@ def run_after_connect(cmd, conn, wait=360):
     # override the Connection parameters
     orig_timeout = conn.connect_timeout
     conn.connect_timeout = 60
-    timeout = time.time() + 60 * 3
+    timeout = time.time() + wait
     latest_exception = None
 
     try:

--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -22,10 +22,9 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from fabric import Connection
-from paramiko.client import WarningPolicy
 from ..common import (
     build_image,
+    Connection,
     manual_uboot_commit,
     latest_build_artifact,
     run_verbose,
@@ -55,13 +54,7 @@ def config_host(host):
 
 def connection_factory(request, user, host, ssh_priv_key):
     host, port = config_host(host)
-    connect_kwargs = {
-        "password": "",
-        "banner_timeout": 60,
-        "auth_timeout": 60,
-        "look_for_keys": False,
-        "allow_agent": False,
-    }
+    connect_kwargs = {}
     if ssh_priv_key != "":
         connect_kwargs["key_filename"] = ssh_priv_key
     conn = Connection(
@@ -71,12 +64,6 @@ def connection_factory(request, user, host, ssh_priv_key):
         connect_timeout=60,
         connect_kwargs=connect_kwargs,
     )
-    conn.client.set_missing_host_key_policy(WarningPolicy())
-
-    def fin():
-        conn.close()
-
-    request.addfinalizer(fin)
 
     return conn
 
@@ -101,11 +88,6 @@ def connection(request, session_connection):
     request.addfinalizer(collect_coverage)
 
     return session_connection
-
-
-@pytest.fixture(scope="session")
-def second_connection(request, user, host, ssh_priv_key):
-    return connection_factory(request, user, host, ssh_priv_key)
 
 
 def setup_qemu(request, qemu_wrapper, build_dir, conn):


### PR DESCRIPTION
```
    We are using an extremely small subset of Fabric's features, which is
    easily replicated with a small class calling ssh. The upside is that
    it is much more compatible, and the `--capture` option does not need
    to be set to `--capture=no` anymore. This is great for several
    reasons:
    
    * xdist doesn't support this mode.
    * We can get per-test log output by using different `--capture`
      options (such as the default `--capture=fd`).
    * The console isn't flooded with messages anymore.
    * Only the log from failing tests is printed by default.
    
    There is one downside, but this is possible to improve later: Output
    is not printed while the command is running anymore, but only after it
    has finished. This only has a practical effect if going back to the
    `--capture=no` mode though, since the other modes anyway do not print
    anything until the test has finished.
    
    In addition, we need to change slightly how we run commands that need
    to be in the background. Previously we could use
    `multiprocessing.Process`, but this does not work anymore because
    terminating the `Process` does not terminate the ssh sub-process, so
    it sticks around even after killing it. We switch to providing a
    `popen` flag instead, and then tests need to treat this as if they had
    used `subprocess.Popen` directly. On the bright side, we can remove
    `second_connection` which is not needed anymore since every call now
    makes a new connection.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```