### PR TITLE
test: Time out properly when ssh server on device dies.

### DIFF
--- a/tests/utils/common/common.py
+++ b/tests/utils/common/common.py
@@ -69,6 +69,8 @@ class Connection:
                 "-o",
                 f"ConnectTimeout={self.connect_timeout}",
                 "-o",
+                "ServerAliveInterval=60",
+                "-o",
                 "UserKnownHostsFile=/dev/null",
                 "-o",
                 "StrictHostKeyChecking=no",


### PR DESCRIPTION
TCP keep-alives are enabled by default on SSH connections, but it doesn't help because the connection is terminated at the QEMU process, which is fine. QEMU has then proxied the connection inside its VM to the ssh server, but this is a separate connection, which never times out, and which we have no control over.

Luckily, SSH has a protocol keep-alive mechanism as well, which is end-to-end, it's just not enabled by default.

Keeping this interval very long in order to deal with slow CI runners is probably not necessary, because there is no payload traffic going over it, so it should not be affected by load.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>