### PR TITLE
QA-487: feat: Split between platform and software tests

### DIFF
--- a/tests/test_part_image.py
+++ b/tests/test_part_image.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ def get_data_part_number(disk_image):
         return 4
 
 
+@pytest.mark.platform_test
 @pytest.mark.only_with_image("sdimg", "uefiimg")
 @pytest.mark.min_mender_version("1.0.0")
 class TestMostPartitionImages:
@@ -374,6 +375,7 @@ class TestMostPartitionImages:
                 os.close(old_cwd_fd)
 
 
+@pytest.mark.platform_test
 @pytest.mark.only_with_image("sdimg", "uefiimg", "biosimg", "gptimg")
 @pytest.mark.min_mender_version("1.0.0")
 class TestAllPartitionImages:

--- a/tests/test_rootfs.py
+++ b/tests/test_rootfs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ from utils.common import (
 )
 
 
+@pytest.mark.platform_test
 class TestRootfs:
     @staticmethod
     def verify_fstab(data):

--- a/tests/test_secure_boot.py
+++ b/tests/test_secure_boot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 import pytest
 
 
+@pytest.mark.platform_test
+@pytest.mark.software_test
 @pytest.mark.only_with_image("uefiimg")
 @pytest.mark.usefixtures("setup_board")
 class TestSecureBoot:

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -72,6 +72,7 @@ class SignatureCase:
         self.success = success
 
 
+@pytest.mark.software_test
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestUpdates:
     @pytest.mark.min_mender_version("1.0.0")

--- a/tests/test_update_modules.py
+++ b/tests/test_update_modules.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import pytest
 from utils.common import put_no_sftp
 
 
+@pytest.mark.software_test
 @pytest.mark.min_yocto_version("kirkstone")
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestUpdateModules:

--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -770,3 +770,25 @@ def commercial_test(request, bitbake_variables):
     mark = request.node.get_closest_marker("commercial")
     if mark is not None and not request.config.getoption("--commercial-tests"):
         pytest.skip("Tests of commercial features are disabled.")
+
+
+@pytest.fixture(scope="function", autouse=True)
+def platform_or_software_test(request):
+    mark_platform = request.node.get_closest_marker("platform_test")
+    mark_software = request.node.get_closest_marker("software_test")
+    if mark_platform is None and mark_software is None:
+        pytest.fail(
+            (
+                "%s must be marked with @pytest.mark.platform_test, @pytest.mark.software_test,"
+                + "or both."
+            )
+            % str(request.node)
+        )
+
+    if mark_platform and mark_software:
+        # Always run
+        pass
+    elif mark_platform and not request.config.getoption("--platform-tests"):
+        pytest.skip("Platform tests are disabled.")
+    elif mark_software and not request.config.getoption("--software-tests"):
+        pytest.skip("Software tests are disabled.")

--- a/tests/utils/parseropts/parseropts.py
+++ b/tests/utils/parseropts/parseropts.py
@@ -1,3 +1,18 @@
+#!/usr/bin/python
+# Copyright 2023 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os
 import pytest
 
@@ -98,12 +113,17 @@ def pytest_addoption(parser):
         action="store_true",
         help="Enable tests of commercial features",
     )
-
     parser.addoption(
         "--hardware-testing",
         action="store_true",
         default=False,
         help="Run the test with real hardware",
+    )
+    parser.addoption(
+        "--platform-tests", action="store_true", help="Run platform tests",
+    )
+    parser.addoption(
+        "--software-tests", action="store_true", help="Run software tests",
     )
 
 
@@ -146,3 +166,14 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "not_for_machine: exclude only for the given machine"
     )
+    config.addinivalue_line("markers", "platform_test: build time platform test")
+    config.addinivalue_line("markers", "software_test: runtime software test")
+
+    #
+    # User options validation
+    if not config.getoption("--platform-tests") and not config.getoption(
+        "--software-tests"
+    ):
+        pytest.fail(
+            "No tests to run, specify --platform-tests, --software-tests or both"
+        )


### PR DESCRIPTION
Use two markers and two command line options to mark/select which tests to run. All tests must have at least one marker and all user calls must have at least one option enabled.

Mark then all tests accordingly.