### PR TITLE
QA-487: feat: Split out cross-platform tests

### DIFF
--- a/tests/test_part_image.py
+++ b/tests/test_part_image.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -187,6 +187,7 @@ class TestMostPartitionImages:
         assert parts_end[3] <= total_size
         assert parts_end[3] >= total_size - part_overhead
 
+    @pytest.mark.cross_platform
     def test_device_type(self, bitbake_path, bitbake_variables, latest_part_image):
         """Test that device type file is correctly embedded."""
 
@@ -218,6 +219,7 @@ class TestMostPartitionImages:
 
             fd.close()
 
+    @pytest.mark.cross_platform
     def test_data_ownership(self, bitbake_path, bitbake_variables, latest_part_image):
         """Test that the owner of files on the data partition is root."""
 
@@ -312,6 +314,7 @@ class TestMostPartitionImages:
                 os.fchdir(old_cwd_fd)
                 os.close(old_cwd_fd)
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_yocto_version("warrior")
     def test_split_mender_conf(
         self, bitbake_path, bitbake_variables, latest_part_image
@@ -341,6 +344,7 @@ class TestMostPartitionImages:
                 os.fchdir(old_cwd_fd)
                 os.close(old_cwd_fd)
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("2.6.0")
     def test_expected_data_dirs(
         self, conversion, bitbake_path, bitbake_variables, latest_part_image

--- a/tests/test_rootfs.py
+++ b/tests/test_rootfs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2020 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -67,13 +67,14 @@ class TestRootfs:
         )
         assert os.access(os.path.join(tmpdir, filename), os.X_OK)
 
+    @pytest.mark.cross_platform
     @pytest.mark.only_with_mender_feature("mender-client-install")
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
     @pytest.mark.min_mender_version("2.5.0")
     def test_expected_files_ext234(
         self, bitbake_path, bitbake_variables, latest_rootfs
     ):
-        """Test mender client expected files"""
+        """Test fstab contents and mender client expected files"""
 
         with make_tempdir() as tmpdir:
             subprocess.check_call(
@@ -139,6 +140,7 @@ class TestRootfs:
                 ),
             )
 
+    @pytest.mark.cross_platform
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
     @pytest.mark.min_mender_version("2.5.1")
     def test_expected_files_ext234_mender_connect(
@@ -181,6 +183,7 @@ class TestRootfs:
                 assert "ShellCommand" in mender_connect_vars, mender_connect_vars
                 assert "User" in mender_connect_vars, mender_connect_vars
 
+    @pytest.mark.cross_platform
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
     @pytest.mark.min_mender_version("2.6.0")
     def test_expected_files_ext234_mender_configure(
@@ -246,6 +249,7 @@ class TestRootfs:
             assert "Type: symlink" in output
             assert 'Fast link dest: "/data/mender-configure"' in output
 
+    @pytest.mark.cross_platform
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
     @pytest.mark.min_mender_version("3.1.0")
     def test_expected_files_ext234_mender_monitor(
@@ -273,7 +277,7 @@ class TestRootfs:
     @pytest.mark.only_with_image("ubifs")
     @pytest.mark.min_mender_version("1.2.0")
     def test_expected_files_ubifs(self, bitbake_path, bitbake_variables, latest_ubifs):
-        """Test that artifact_info file is correctly embedded."""
+        """Test fstab contents on UBI File System."""
 
         with make_tempdir() as tmpdir:
             # NOTE: ubireader_extract_files can keep permissions only if

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -174,6 +174,7 @@ class TestUpdates:
             assert output.find(active_before) >= 0
             assert output.find(passive_before) < 0
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.0.0")
     def test_too_big_image_update(self, bitbake_variables, connection):
 
@@ -586,6 +587,7 @@ class TestUpdates:
             ),
         ],
     )
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("1.1.0")
     def test_signed_updates(self, sig_case, bitbake_variables, connection):
         """Test various combinations of signed and unsigned, present and non-
@@ -985,6 +987,7 @@ class TestUpdates:
                     )
                     connection.run("rm -f /data/old_env%d" % i)
 
+    @pytest.mark.cross_platform
     @pytest.mark.min_mender_version("2.3.1")
     def test_standalone_update_rollback(self, bitbake_variables, connection):
         """Test that the rollback state on the active partition does roll back to the

--- a/tests/test_update_modules.py
+++ b/tests/test_update_modules.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# Copyright 2022 Northern.tech AS
+# Copyright 2023 Northern.tech AS
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import pytest
 from utils.common import put_no_sftp
 
 
+@pytest.mark.cross_platform
 @pytest.mark.min_yocto_version("kirkstone")
 @pytest.mark.usefixtures("setup_board", "bitbake_path")
 class TestUpdateModules:

--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -767,3 +767,14 @@ def commercial_test(request, bitbake_variables):
     mark = request.node.get_closest_marker("commercial")
     if mark is not None and not request.config.getoption("--commercial-tests"):
         pytest.skip("Tests of commercial features are disabled.")
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cross_platform_test(request):
+    mark = request.node.get_closest_marker("cross_platform")
+    option_no = request.config.getoption("--no-cross-platform-tests")
+    option_only = request.config.getoption("--only-cross-platform-tests")
+    if mark and option_no:
+        pytest.skip("Not running cross-platform tests.")
+    if not mark and option_only:
+        pytest.skip("Running only cross-platform tests.")

--- a/tests/utils/parseropts/parseropts.py
+++ b/tests/utils/parseropts/parseropts.py
@@ -112,12 +112,23 @@ def pytest_addoption(parser):
         action="store_true",
         help="Enable tests of commercial features",
     )
-
     parser.addoption(
         "--hardware-testing",
         action="store_true",
         default=False,
         help="Run the test with real hardware",
+    )
+    parser.addoption(
+        "--no-cross-platform-tests",
+        action="store_true",
+        default=False,
+        help="Do not run platform agnostic tests",
+    )
+    parser.addoption(
+        "--only-cross-platform-tests",
+        action="store_true",
+        default=False,
+        help="Run platform agnostic tests only",
     )
 
 
@@ -160,3 +171,4 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "not_for_machine: exclude only for the given machine"
     )
+    config.addinivalue_line("markers", "cross_platform: platform agnostic test")

--- a/tests/utils/parseropts/parseropts.py
+++ b/tests/utils/parseropts/parseropts.py
@@ -1,3 +1,17 @@
+# Copyright 2023 Northern.tech AS
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os
 import pytest
 


### PR DESCRIPTION
    Use a marker and two command line options to mark and select/deselect
    tests that are platform agnostic.
    
    The default behavior will be the same (aka run all tests), while the
    user  can optionally skipping the platform agnostic tests or run them
    exclusively.
    
    Mark then all tests accordingly. Along the way, minor tests doc
    improvements have been made.