### PR TITLE
test: Set minimum version for C++ related handling to `3.6.0`

### DIFF
--- a/tests/test_rootfs.py
+++ b/tests/test_rootfs.py
@@ -22,6 +22,7 @@ import pytest
 from utils.common import (
     make_tempdir,
     version_is_minimum,
+    is_cpp_client,
 )
 
 
@@ -131,7 +132,7 @@ class TestRootfs:
                 "io.mender.AuthenticationManager.conf",
                 True,
             )
-            if not version_is_minimum(bitbake_variables, "mender-client", "4.0.0"):
+            if not is_cpp_client(bitbake_variables):
                 self.verify_file_exists(
                     tmpdir,
                     latest_rootfs,
@@ -149,6 +150,12 @@ class TestRootfs:
                     bitbake_variables, "mender-client", "3.5.0"
                 ),
             )
+
+            if is_cpp_client(bitbake_variables):
+                # Check whether mender-flash exists in /usr/bin
+                self.verify_file_exists(
+                    tmpdir, latest_rootfs, "/usr/bin", "mender-flash", True
+                )
 
     @pytest.mark.cross_platform
     @pytest.mark.only_with_image("ext4", "ext3", "ext2")
@@ -283,20 +290,6 @@ class TestRootfs:
             ).decode()
             assert "Type: symlink" in output
             assert 'Fast link dest: "/data/mender-monitor"' in output
-
-    @pytest.mark.cross_platform
-    @pytest.mark.only_with_image("ext4", "ext3", "ext2")
-    @pytest.mark.min_mender_version("4.0.0")
-    def test_expected_files_ext234_mender_flash(
-        self, bitbake_path, bitbake_variables, latest_rootfs
-    ):
-        """Test mender-flash expected files"""
-
-        with make_tempdir() as tmpdir:
-            # Check whether mender-flash exists in /usr/bin
-            self.verify_file_exists(
-                tmpdir, latest_rootfs, "/usr/bin", "mender-flash", True
-            )
 
     @pytest.mark.only_with_image("ubifs")
     @pytest.mark.min_mender_version("1.2.0")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -31,7 +31,7 @@ from utils.common import (
     reboot,
     run_after_connect,
     signing_key,
-    version_is_minimum,
+    is_cpp_client,
 )
 from utils.helpers import Helpers
 
@@ -618,9 +618,7 @@ class TestUpdates:
         """Test various combinations of signed and unsigned, present and non-
         present verification keys."""
 
-        if sig_case.artifact_version == 2 and version_is_minimum(
-            bitbake_variables, "mender", "4.0.0"
-        ):
+        if sig_case.artifact_version == 2 and is_cpp_client(bitbake_variables):
             pytest.skip(
                 "Artifact format version 2 not supported in Mender client 4.0.0 and later"
             )

--- a/tests/utils/common/common.py
+++ b/tests/utils/common/common.py
@@ -693,6 +693,15 @@ def version_is_minimum(bitbake_variables, component, min_version, recurse=True):
     return version_parsed >= packaging.version.Version(min_version)
 
 
+def is_cpp_client(bitbake_variables):
+    # The actual C++ client tag is going to be `4.0.0`. However, the mender-convert
+    # tests set the versions based on the deb packages which, before final tag,
+    # looks like `3.6.0~something`. Use here 3.6.0 so that the fixtures run correctly.
+    # In any case `4.0.0 > 3.6.0` so it doesn't matter that it is not a real tag.
+
+    return version_is_minimum(bitbake_variables, "mender", "3.6.0")
+
+
 @contextmanager
 def make_tempdir(delete=True):
     """context manager for temporary directories"""

--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -43,6 +43,7 @@ from ..common import (
     get_no_sftp,
     get_bitbake_variables,
     version_is_minimum,
+    is_cpp_client,
 )
 
 
@@ -799,7 +800,7 @@ def cross_platform_test(request):
 
 @pytest.fixture(scope="session")
 def mender_auth_binary(bitbake_variables):
-    if version_is_minimum(bitbake_variables, "mender", "4.0.0"):
+    if is_cpp_client(bitbake_variables):
         return "mender-auth"
     else:
         return "mender"
@@ -807,7 +808,7 @@ def mender_auth_binary(bitbake_variables):
 
 @pytest.fixture(scope="session")
 def mender_update_binary(bitbake_variables):
-    if version_is_minimum(bitbake_variables, "mender", "4.0.0"):
+    if is_cpp_client(bitbake_variables):
         return "mender-update"
     else:
         return "mender"
@@ -815,7 +816,7 @@ def mender_update_binary(bitbake_variables):
 
 @pytest.fixture(scope="session")
 def mender_auth_service(bitbake_variables):
-    if version_is_minimum(bitbake_variables, "mender", "4.0.0"):
+    if is_cpp_client(bitbake_variables):
         return "mender-authd"
     else:
         return "mender-client"
@@ -823,7 +824,7 @@ def mender_auth_service(bitbake_variables):
 
 @pytest.fixture(scope="session")
 def mender_update_service(bitbake_variables):
-    if version_is_minimum(bitbake_variables, "mender", "4.0.0"):
+    if is_cpp_client(bitbake_variables):
         return "mender-updated"
     else:
         return "mender-client"


### PR DESCRIPTION
Using a different helper to document in code (and only once) why we need
this unintuitive change.

Merge the `mender-flash` test with the main client files test so that we
can reuse also the new helper. The main test was already differentiating
from golang to C++ anyway.