### PR TITLE
test: Remove test for mender.conf, which is less relevant now. 

### DIFF
--- a/tests/test_rootfs.py
+++ b/tests/test_rootfs.py
@@ -310,13 +310,3 @@ class TestRootfs:
             with open(path) as fd:
                 data = fd.read()
             TestRootfs.verify_fstab(data)
-
-    @pytest.mark.only_with_mender_feature("mender-convert")
-    @pytest.mark.min_mender_version("1.0.0")
-    def test_unconfigured_image(self, latest_rootfs):
-        """Test that images from mender-convert are unconfigured. We want
-        `mender setup` to be the configuration mechanism there."""
-        output = subprocess.check_output(
-            ["debugfs", "-R", "ls -l -p /etc/mender", latest_rootfs]
-        ).decode()
-        assert "mender.conf" not in output


### PR DESCRIPTION
Both conditions can be true; if Mender is installed, then the file
will be there, if it's not installed, then it won't. We don't track
this condition in the tests currently.

Since we now run package scripts, it's better to test this condition
in mender-dist-packages anyway, so just remove it from here.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>