### PR TITLE
feat: add connection fixture session scope copy

### DIFF
--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -90,9 +90,15 @@ def connection_factory(request, user, host, ssh_priv_key):
     return conn
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def session_connection(request, user, host, ssh_priv_key):
-    return connection_factory(request, user, host, ssh_priv_key)
+    """
+    Fixture for a connection to the build host.
+    Stored in the config object so it can be used in test session finish hook.
+    """
+    session_conn = connection_factory(request, user, host, ssh_priv_key)
+    request.config._session_connection = session_conn
+    return session_conn
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Adds session-scoped connection fixture with autouse so the fixture can be used in session finish hook.

Ticket: QA-1099