### PR TITLE
Revert "feat: add connection fixture session scope copy"

### DIFF
--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -90,15 +90,9 @@ def connection_factory(request, user, host, ssh_priv_key):
     return conn
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def session_connection(request, user, host, ssh_priv_key):
-    """
-    Fixture for a connection to the build host.
-    Stored in the config object so it can be used in test session finish hook.
-    """
-    session_conn = connection_factory(request, user, host, ssh_priv_key)
-    request.config._session_connection = session_conn
-    return session_conn
+    return connection_factory(request, user, host, ssh_priv_key)
 
 
 @pytest.fixture(scope="function")
@@ -163,6 +157,17 @@ def setup_qemu(request, qemu_wrapper, build_dir, conn):
     # cases more predictable.
     def qemu_finalizer():
         def qemu_finalizer_impl(conn):
+
+            # collect logs before shutting down
+            try:
+                # TODO: this should be a configurable list of logs to collect
+                log_path = "/tmp/journalctl.log"
+                conn.run(f"journalctl --no-pager > {log_path}")
+                get_no_sftp(log_path, conn, local=log_path)
+                print("QEMU machine logs collected successfully before shutdown.")
+            except Exception as e:
+                print(f"Failed to collect QEMU logs before shutdown: {e}")
+
             shutdown_timeout_s = 30
             # Try clearing firmware variables
             try:


### PR DESCRIPTION
This reverts commit 15ea5589d1df30bbec2ac782ab7071e4291480ab.

This attempt was a dead end. By the time pytest reaches pytest_sessionfinish() the QEMU instance is long gone, so doing anything with the session connection has to be done elsewhere

Instead this adds the log collection attempt into the qemu finalizer, right before the finalizer tries to shut down the qemu VM