### PR TITLE
test: archive journal logs from live QEMU VM

### DIFF
--- a/tests/utils/fixtures/fixtures.py
+++ b/tests/utils/fixtures/fixtures.py
@@ -160,9 +160,12 @@ def setup_qemu(request, qemu_wrapper, build_dir, conn):
 
             # collect logs before shutting down
             try:
-                # TODO: this should be a configurable list of logs to collect
-                log_path = "/tmp/journalctl.log"
-                conn.run(f"journalctl --no-pager > {log_path}")
+                # save log for each test worker so theyx don't overwrite the file for each other
+                worker_index = get_worker_index()
+                log_path = f"/tmp/journalctl-qemu-logs-worker{worker_index}.log"
+                conn.run(
+                    f"journalctl --sync && journalctl --no-pager --all > {log_path}",
+                )
                 get_no_sftp(log_path, conn, local=log_path)
                 print("QEMU machine logs collected successfully before shutdown.")
             except Exception as e:


### PR DESCRIPTION
- adds a step right before the QEMU VM ran by tests is powered off to attempt to retrieve journal logs from the VM
- places the logs under `/tmp` so they can be picked up as job artifacts by the CI (TODO: add link to the PR with CI changes)

Ticket: QA-1099